### PR TITLE
fix: correct matchManagers for renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,7 +45,7 @@
   ],
   "packageRules": [
     {
-      "matchManagers": ["nix"],
+      "matchManagers": ["regex"],
       "matchPackageNames": ["sst/opencode"],
       "automerge": true,
       "automergeType": "pr"


### PR DESCRIPTION
Automerge was not activating for opencode Renovate PRs because the renovate config matched the wrong manager type. This changes matchManagers from 'nix' to 'regex' to align with custom managers that use customType: regex and enable automerge for opencode Renovate PRs.