### PR TITLE
Revert "chore: update opencode to 1.1.23"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1768395095,
-        "narHash": "sha256-ZhuYJbwbZT32QA95tSkXd9zXHcdZj90EzHpEXBMabaw=",
+        "lastModified": 1768302833,
+        "narHash": "sha256-h5bRFy9bco+8QcK7rGoOiqMxMbmn21moTACofNLRMP4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13868c071cc73a5e9f610c47d7bb08e5da64fdd5",
+        "rev": "61db79b0c6b838d9894923920b612048e1201926",
         "type": "github"
       },
       "original": {
@@ -70,16 +70,16 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1768514474,
-        "narHash": "sha256-cvz4HO5vNwA3zWx7zdVfs59Z7vD/00+MMCDbLU5WKpM=",
+        "lastModified": 1768444447,
+        "narHash": "sha256-8ykONBWMiq9EACHOsdx1AFPoj53Tsxi3EbUDVciH5Ok=",
         "owner": "anomalyco",
         "repo": "opencode",
-        "rev": "df8e6e601416363b7b620f953ec9b2f1b59ba11a",
+        "rev": "99a1e73fa1bd5c92c02abd8a20b0e274d5b0d214",
         "type": "github"
       },
       "original": {
         "owner": "anomalyco",
-        "ref": "v1.1.23",
+        "ref": "v1.1.21",
         "repo": "opencode",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     # NOTE: nixpkgs-unstable required for packages to build
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    opencode.url = "github:anomalyco/opencode/v1.1.23";
+    opencode.url = "github:anomalyco/opencode/v1.1.21";
   };
 
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:


### PR DESCRIPTION
Reverts ndrwstn/nixautopkgs#217
- hashes broken in 1.1.123